### PR TITLE
FIX CEP Inválido e Cache para Requisições

### DIFF
--- a/app/code/local/Intelipost/Shipping/Model/Carrier/Intelipost.php
+++ b/app/code/local/Intelipost/Shipping/Model/Carrier/Intelipost.php
@@ -29,8 +29,17 @@ class Intelipost_Shipping_Model_Carrier_Intelipost
         $destinationZipCode = $request->getDestPostcode();
 
         if (!preg_match($this->_zipCodeRegex, $originZipCode) || !preg_match($this->_zipCodeRegex, $destinationZipCode)) {
-            Mage::log('Invalid zip code ' . $originZipCode . ' or ' . $destinationZipCode, null, 'intelipost.log', true);
-            return false;
+		$error = Mage::getModel('shipping/rate_result_error');
+		
+		$error->setCarrier('intelipost')
+			->setCarrierTitle('intelipost')
+			->setErrorMessage('CEP Inválido! Por favor, digite o CEP corretamente.');
+	
+		$result->append($error);
+	
+	        Mage::log('Invalid zip code ' . $originZipCode . ' or ' . $destinationZipCode, null, 'intelipost.log', true);
+	
+		return $result;
         }
 
         // only numbers allowed

--- a/app/code/local/Intelipost/Shipping/etc/system.xml
+++ b/app/code/local/Intelipost/Shipping/etc/system.xml
@@ -195,6 +195,26 @@
 				    <show_in_website>1</show_in_website>
 				    <show_in_store>1</show_in_store>
 				</import_process>
+				<showmethod>
+					<label>Show method if not applicable</label>
+					<frontend_type>select</frontend_type>
+					<source_model>adminhtml/system_config_source_yesno</source_model>
+                        		<comment><![CDATA[Only if this option is yes the error messages will be displayed]]></comment>
+					<sort_order>110</sort_order>
+					<show_in_default>1</show_in_default>
+					<show_in_website>1</show_in_website>
+					<show_in_store>1</show_in_store>
+                		</showmethod>				
+                		<cache translate="label">
+					<label>Cache</label>
+					<frontend_type>select</frontend_type>
+					<source_model>adminhtml/system_config_source_yesno</source_model>
+                        		<comment><![CDATA[Essa opção mantem o cache do intelipost por 1 hora para cada usuário]]></comment>
+					<sort_order>150</sort_order>
+					<show_in_default>1</show_in_default>
+					<show_in_website>1</show_in_website>
+					<show_in_store>1</show_in_store>
+				</cache>						
           </fields>
 
         </intelipost>


### PR DESCRIPTION
- Função para avisar o usuário quando o CEP for inválido. Ex: 01311-30
- Nova Função que coloca requisição do webservice em Cache. Assim caso o mesmo usuário não mude nenhuma variável na requisição não é necessário realizar nova consulta no webservice, deixando a finalização do pedido do cliente mais rápida. Cache padrão de 3600 segundos.